### PR TITLE
Add Vercel Web Analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,8 @@
       src="https://stats.sal.fun/script.js"
       data-website-id="56372374-e075-490e-a908-1984d4095255"
     ></script>
+    <!-- Vercel Analytics -->
+    <script defer src="/_vercel/insights/script.js"></script>
     <style>
       @import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Sora:wght@400;600;700&display=swap");
 


### PR DESCRIPTION
Adds Vercel Web Analytics tracking script alongside existing Umami analytics.

Changes:
- Added `/_vercel/insights/script.js` script tag

This enables Vercel's built-in analytics dashboard for page views and visitors.